### PR TITLE
Gradle: Limit Google dependencies

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,21 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("UnstableApiUsage")
 
 pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        google()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
     }
 }
 
-@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
-        google()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Added mavenContent filters to the Google repository in pluginManagement
and dependencyResolutionManagement to include only specific groups.
This change aims to enhance build efficiency by limiting the scope of
dependencies fetched from the Google repository.